### PR TITLE
Bootstrap stack-control + inaugurate Resolve harness roadmap

### DIFF
--- a/.stack-control/audit-log.md
+++ b/.stack-control/audit-log.md
@@ -1,0 +1,5 @@
+# Audit Log
+
+Durable record of audit findings + their dispositions. Status values: `open` → `fixed-<sha>` → `verified-<date>`, or `acknowledged-<date>` with a substantive reason.
+
+---

--- a/.stack-control/backlog/config.yml
+++ b/.stack-control/backlog/config.yml
@@ -1,0 +1,15 @@
+project_name: "backlog"
+default_status: "To Do"
+statuses: ["To Do", "In Progress", "Done"]
+labels: []
+date_format: yyyy-mm-dd
+max_column_width: 80
+auto_open_browser: false
+default_port: 6420
+remote_operations: false
+auto_commit: false
+filesystem_only: true
+bypass_git_hooks: false
+check_active_branches: false
+active_branch_days: 30
+task_prefix: "task"

--- a/.stack-control/config.yaml
+++ b/.stack-control/config.yaml
@@ -1,0 +1,1 @@
+version: 1

--- a/.stack-control/fleet-knowledge.yaml
+++ b/.stack-control/fleet-knowledge.yaml
@@ -1,0 +1,7 @@
+lanes:
+  - name: claude
+    max_prompt_bytes: 65536
+  - name: codex
+    max_prompt_bytes: 24576
+  - name: sonnet
+    max_prompt_bytes: 32768

--- a/DESIGN-INBOX.md
+++ b/DESIGN-INBOX.md
@@ -1,0 +1,9 @@
+---
+doc-grammar: design-inbox
+---
+
+# Design Inbox
+
+A governed, low-friction parking lot for out-of-sequence design ideas. Capture
+and triage with `stackctl inbox` (`capture` / `promote` / `drop` / `list`) —
+do not hand-edit.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,20 @@
+---
+doc-grammar: roadmap
+---
+
+# Roadmap
+
+The governed dependency graph of this project's features. Each item is a
+heading-keyed unit identified by its `<phase>:<kind>/<slug>` id.
+
+Mutate the graph with `stackctl roadmap` verbs (run `stackctl roadmap --help`
+for the full surface): `add` a new item, `advance` its status, `decompose`,
+`reclassify`, `defer`, and `cluster` / `group` to gather existing items under a
+created-or-reused parent. Example — cluster items under a new epic with a
+dependency chain:
+
+    stackctl roadmap cluster multi:feature/epic --children design:feature/a,impl:feature/b --chain --apply
+
+For an edit that has no verb yet (e.g. moving a `part-of` / `depends-on` edge):
+edit this file directly, then run `stackctl roadmap order` to revalidate the
+graph (it fails loud on a cycle / dangling ref / duplicate id).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,3 +18,77 @@ dependency chain:
 For an edit that has no verb yet (e.g. moving a `part-of` / `depends-on` edge):
 edit this file directly, then run `stackctl roadmap order` to revalidate the
 graph (it fails loud on a cycle / dangling ref / duplicate id).
+
+## multi:feature/resolve-automation-harness
+- status: planned
+- ref: docs/product-brief-resolve-harness.md
+A build system for repeatable video production in DaVinci Resolve: agent-driven, repository-based automation harness (CLI + declarative YAML workflows + structured inspection/validation + reusable templates). Opinionated over exhaustive; local, no persistent service. First cycle: macOS-first, already-running Resolve instance, human review before final render.
+
+## design:feature/technical-discovery
+- status: planned
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Phase 0 go/no-go feasibility: map Resolve scripting API coverage (projects/media/timelines/clips/markers/subtitles/Fusion/render), free vs Studio, stable-identifier & snapshot/rollback strategy, GUI-fallback surface. Deliverables: capability matrix, architecture proposal, API risk register, prototype doctor/inspect/render-queue. Exit: reliable connection, structured inspection, test timeline created, test render enqueued+completed, documented limits.
+
+## impl:feature/resolve-connectivity
+- status: planned
+- depends-on: design:feature/technical-discovery
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Milestone 1: CLI foundation. init + doctor diagnostics, Resolve version/edition detection, running-instance detection, project discovery, structured (JSON) project & timeline inspection, actionable connection remediation, stable exit codes.
+
+## impl:feature/deterministic-timeline-build
+- status: planned
+- depends-on: impl:feature/resolve-connectivity
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Milestone 2: deterministic timeline construction. Media import, bin management, timeline creation, clip append/trim, markers, and a project-local state manifest enabling idempotent re-runs (tag generated entities; compare desired vs current).
+
+## impl:feature/workflow-execution-engine
+- status: planned
+- depends-on: impl:feature/deterministic-timeline-build
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Milestone 3: workflow engine. YAML workflow schema + plan/apply/dry-run, dependency-ordered execution, execution journals, postcondition checks, snapshots, safe re-run without uncontrolled duplication (replace/merge/rebuild modes).
+
+## impl:feature/review-render-pipeline
+- status: planned
+- depends-on: impl:feature/workflow-execution-engine
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Milestone 4: render pipeline. Render preset selection, render-queue control, status inspection, review + final outputs, output/path validation, preflight gating that blocks final render on failed checks unless explicitly overridden.
+
+## impl:feature/screen-walkthrough-mvp
+- status: planned
+- depends-on: impl:feature/review-render-pipeline
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Milestone 5 / MVP: first packaged workflow, screen-recording product walkthrough with voiceover. Sync screen+narration, configurable pause reduction, captions when transcript present, chapter markers, intro/outro, review + final render, execution report. Human review required before final render. Tests the full thesis end to end.
+
+## impl:feature/developer-preview
+- status: planned
+- depends-on: impl:feature/screen-walkthrough-mvp
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Milestone 6: Developer Preview packaging. Installer, example projects, compatibility/capability matrix docs, feedback instrumentation, issue templates, extension documentation.
+
+## multi:feature/workflow-productization
+- status: planned
+- depends-on: impl:feature/developer-preview
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Phase 2: from toolkit to repeatable end-user workflows. Schema validation, reusable workflow packages, template/preset registry, parameterized titles, caption workflow, audio/missing-media checks, preflight, revision-safe regeneration. Exit: 3+ workflows configurable without code changes.
+
+## multi:feature/intelligent-editing-assist
+- status: planned
+- depends-on: multi:feature/workflow-productization
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Phase 3: AI-assisted editorial as recommendations, not silent edits. Transcript-to-timeline mapping, silence/filler removal, retake detection, chapter/highlight suggestion, speaker segmentation. Suggestions must be evidence-traceable, acceptable/rejectable, deterministic on apply, and explainable.
+
+## multi:feature/team-pipeline-capabilities
+- status: planned
+- depends-on: multi:feature/workflow-productization
+- part-of: multi:feature/resolve-automation-harness
+- ref: docs/product-brief-resolve-harness.md
+Phase 4: shared production standards & content operations. Shared workflow registry, org presets, template versioning, CI validation, batch execution, render nodes, approval metadata, publishing/asset integrations, project locking/concurrency.

--- a/docs/product-brief-resolve-harness.md
+++ b/docs/product-brief-resolve-harness.md
@@ -1,0 +1,687 @@
+# Product Brief: Agent-Driven Automation Harness for DaVinci Resolve
+
+> Roadmap-level brief framed for product management review and prioritization.
+> This document is the source of truth for the roadmap items under
+> `multi:feature/resolve-automation-harness`. See `ROADMAP.md` for the governed
+> dependency graph derived from it.
+
+## Executive Summary
+
+This proposal outlines an opinionated automation harness that enables coding
+agents to perform repeatable, inspectable, and reliable video-production
+workflows in DaVinci Resolve.
+
+Rather than exposing Resolve through a long-running MCP server or a broad set of
+low-level API tools, the product would provide a local, repository-based
+automation environment. Coding agents would interact with Resolve through a
+purpose-built command-line interface, declarative workflow specifications,
+structured inspection commands, and reusable production templates.
+
+The product goal is not to make every Resolve function available to an agent. It
+is to make a smaller set of high-value video workflows dependable enough to use
+repeatedly in real production work.
+
+The initial focus should be on workflows such as screen-recording edits,
+talking-head videos, product walkthroughs, podcast episodes, captioning, social
+cutdowns, and multi-format rendering.
+
+## Product Vision
+
+Create a reliable automation layer between coding agents and DaVinci Resolve that
+lets users describe, configure, execute, inspect, and revise video-production
+workflows using files, commands, and version-controlled project conventions.
+
+The harness should make video production behave more like a software build
+system:
+
+1. Source media and workflow configuration are inputs.
+2. Resolve timelines and rendered deliverables are generated outputs.
+3. Agents can inspect state, modify configuration, run workflows, validate
+   results, and iterate.
+4. Production rules and editorial conventions are encoded in the repository
+   rather than rediscovered during every session.
+
+## Problem Statement
+
+DaVinci Resolve provides a scripting API, but using it directly presents several
+challenges:
+
+- The API is broad, inconsistent in places, and oriented around low-level
+  application objects.
+- Coding agents need substantial context before they can safely manipulate
+  projects and timelines.
+- Many operations are stateful and difficult to make idempotent.
+- Resolve projects are not naturally represented as text that can be reviewed or
+  version controlled.
+- Generic agent integrations often expose too many primitives without enough
+  workflow guidance.
+- Long-running integration services require configuration, process management,
+  and troubleshooting.
+- Agents may successfully issue commands without confirming that the expected
+  timeline or render state was produced.
+- Destructive changes can be difficult to reverse or audit.
+
+Users need an automation model that is available on demand, understandable by
+coding agents, and reliable enough for repeated use.
+
+## Target Users
+
+### Primary Users
+
+**Technical Content Creators** — People producing product walkthroughs,
+tutorials, developer education, screen recordings, and technical presentations.
+Typical needs: remove pauses and failed takes; synchronize narration and screen
+recordings; add reusable titles and lower thirds; generate captions and chapter
+markers; render multiple publishing formats; reuse editorial conventions across a
+series.
+
+**Developer-Creators** — Developers already using tools such as Codex, Claude
+Code, or other coding agents who want to automate media-production work through
+repositories and command-line workflows. Typical needs: script repeatable editing
+processes; store production configuration in Git; build custom workflow
+extensions; inspect timelines in machine-readable form; integrate video
+production into broader content pipelines.
+
+**Small Content and Marketing Teams** — Teams producing recurring video assets
+without dedicated video-automation engineering resources. Typical needs:
+standardize output across contributors; reduce repetitive editor work; reuse
+brand and export presets; produce consistent deliverables from structured inputs;
+review workflow changes before applying them.
+
+### Secondary Users
+
+- Podcast producers
+- Training and enablement teams
+- Social media teams
+- Internal communications teams
+- Agencies managing repeatable client formats
+
+## Jobs to Be Done
+
+**Core Job** — When I have raw video, audio, transcripts, and production
+requirements, I want a coding agent to assemble and update a Resolve project
+through a controlled workflow so that I can produce consistent deliverables
+without manually repeating the same editing steps.
+
+**Supporting Jobs**
+
+- Inspect the current state of a Resolve project without opening and navigating
+  the interface manually.
+- Rebuild a timeline from a declarative specification.
+- Make a narrowly scoped revision without disrupting the rest of the project.
+- Apply standardized intros, outros, titles, captions, and render presets.
+- Generate multiple deliverables from one approved timeline.
+- Record what the agent changed and verify that the expected result occurred.
+- Extend the system with organization-specific production conventions.
+
+## Product Principles
+
+- **Opinionated Over Exhaustive** — Prioritize reliable workflows over complete
+  API coverage. `resolve-tool workflow run screen-demo` is more valuable than
+  exposing hundreds of thin wrappers around Resolve API methods.
+- **Repository as the Control Plane** — Workflow definitions, agent instructions,
+  templates, presets, validation rules, and production metadata live in a local
+  project repository, useful even when no agent or Resolve process is running.
+- **Inspect Before Mutate** — Agents can query project, timeline, clip,
+  media-pool, and render state through structured commands before making changes.
+- **Declarative Where Practical** — Users describe intended outputs rather than
+  manually specifying every Resolve operation.
+- **Safe by Default** — Broad or destructive operations require snapshots,
+  validation, dry runs, or explicit override flags.
+- **Observable and Auditable** — Every workflow run produces structured logs, an
+  execution journal, and postcondition checks.
+- **Human Approval at Meaningful Boundaries** — Automate repetitive work while
+  preserving clear review points before destructive edits, final timeline
+  replacement, and publication-quality rendering.
+
+## Proposed Product
+
+The product would consist of five primary layers.
+
+### 1. Resolve Automation CLI
+
+A command-line interface used by coding agents and human operators. Illustrative
+commands:
+
+```
+resolve-tool doctor
+resolve-tool inspect project --json
+resolve-tool inspect timeline --include-clips --json
+resolve-tool media import ./footage --bin "Source"
+resolve-tool timeline snapshot
+resolve-tool workflow validate video.yaml
+resolve-tool workflow run screen-demo --config video.yaml
+resolve-tool render enqueue youtube
+resolve-tool render start --wait
+```
+
+The CLI should provide: consistent command syntax; structured JSON output;
+human-readable output; stable exit codes; dry-run support; explicit error
+categories; idempotency where possible; validation before execution.
+
+### 2. Declarative Workflow Specification
+
+A YAML or JSON format describing the desired video structure and production
+rules. Example:
+
+```yaml
+project: Product Walkthrough
+timeline: Main Edit
+sources:
+  screen:
+    path: footage/screen-recording.mov
+  narration:
+    path: audio/voiceover.wav
+edit:
+  remove_silence:
+    source: narration
+    minimum_duration: 0.7
+    padding: 0.12
+captions:
+  source: transcript.json
+  style: standard-captions
+overlays:
+  - template: lower-third
+    start: 00:00:12.000
+    duration: 4
+    values:
+      title: Product Name
+      subtitle: Feature Overview
+outputs:
+  - preset: youtube-4k
+  - preset: review-1080p
+```
+
+The harness would compile this specification into Resolve operations.
+
+### 3. Opinionated Workflow Library
+
+Reusable workflows for common production patterns. Initial candidates:
+screen-recording tutorial; talking-head video; product walkthrough; podcast
+episode; captioned social clip; long-form-to-short-form cutdown; review render;
+multi-format final export. Each workflow encodes assumptions about track layout,
+naming conventions, media organization, audio handling, title placement, caption
+generation, render presets, and validation requirements.
+
+### 4. Inspection and Validation Layer
+
+Inspection should cover: projects, timelines, tracks, clips, markers, media pool
+and bins, missing media, timeline settings, render queue, render status, applied
+workflow metadata. Validation should cover: media availability, expected frame
+rate, timeline resolution, audio track presence, peak audio thresholds, caption
+availability, output path validity, required templates, render preset
+availability, workflow postconditions.
+
+### 5. Agent Guidance and Extension Framework
+
+The harness should include an `AGENTS.md` or equivalent policy file that defines
+operating rules for coding agents. Example rules: never modify the ingest
+timeline; create a snapshot before changing more than five clips; inspect the
+active project and timeline before mutation; prefer editing workflow
+configuration over direct timeline manipulation; run validation before final
+rendering; do not publish or upload deliverables without explicit approval; use
+named GUI fallbacks only when an operation is not supported by the Resolve API.
+
+The extension framework should allow teams to add custom workflows, render
+presets, title templates, organization-specific validation rules, media-processing
+steps, and post-render hooks.
+
+## Product Scope
+
+**In Scope for Initial Product** — Local execution; macOS support; DaVinci
+Resolve Studio and free-edition capability detection; Resolve connectivity and
+environment diagnostics; project and timeline inspection; media import and bin
+organization; timeline creation; clip placement and basic trimming; marker
+creation; subtitle import; basic title and template insertion; render preset
+selection; render queue management; workflow configuration; snapshots and
+execution journals; agent instruction templates; dry-run and validation modes.
+
+**Potentially In Scope Later** — Windows and Linux support; transcript-driven
+editing; silence and filler-word removal; automatic take selection; speaker-aware
+podcast editing; audio loudness normalization; multi-camera synchronization;
+B-roll recommendation and insertion; automated social cutdowns; Fusion template
+parameterization; review and approval interfaces; remote render nodes; cloud
+asset storage integrations; publishing integrations; team workflow registry.
+
+**Explicitly Out of Scope Initially** — Full replacement for the Resolve user
+interface; complete exposure of every Resolve scripting API method; real-time
+collaborative editing; autonomous publishing without user approval;
+general-purpose GUI automation; generative video creation; fully automatic
+creative editing without workflow constraints; hosted multi-tenant Resolve
+control service.
+
+## User Experience
+
+### Initial Setup
+
+```
+pipx install resolve-tool
+resolve-tool init
+resolve-tool doctor
+```
+
+The initialization process creates:
+
+```
+video-project/
+├── AGENTS.md
+├── video.yaml
+├── footage/
+├── audio/
+├── transcripts/
+├── templates/
+├── presets/
+├── artifacts/
+└── logs/
+```
+
+### Typical Agent Workflow
+
+1. The user opens the repository with a coding agent.
+2. The agent reads `AGENTS.md` and the workflow configuration.
+3. The agent runs `resolve-tool doctor`.
+4. The agent inspects the active Resolve project.
+5. The agent validates the workflow.
+6. The agent performs a dry run.
+7. The agent executes the workflow.
+8. The harness verifies postconditions.
+9. The agent reports changes and identifies items requiring review.
+10. The user reviews the timeline or review render.
+11. The agent applies revisions and produces final deliverables.
+
+### Example User Request
+
+> Build a first-pass edit from the screen recording and voiceover, remove pauses
+> longer than 0.8 seconds, add captions, apply the standard intro and outro, and
+> create a 1080p review render.
+
+The agent would modify or generate the workflow configuration, validate it,
+execute the workflow, and report the resulting timeline and render state.
+
+## Key Use Cases
+
+**Use Case 1: Product Walkthrough** — Inputs: screen recording, voiceover,
+transcript, intro/outro templates, brand title template. Outputs: synchronized
+main timeline, silence-reduced edit, lower thirds, captions, chapter markers,
+review render, final publishing render.
+
+**Use Case 2: Talking-Head Tutorial** — Inputs: camera recording, external
+microphone recording, transcript, B-roll folder. Outputs: synchronized timeline,
+basic jump-cut edit, captions, reusable title treatment, loudness-checked audio,
+YouTube and social outputs.
+
+**Use Case 3: Podcast Episode** — Inputs: multiple camera or audio sources,
+speaker metadata, transcript. Outputs: synchronized multicam or audio timeline,
+speaker markers, full-length episode, chapter markers, selected short clips,
+audio-only export.
+
+**Use Case 4: Batch Social Cutdowns** — Inputs: approved long-form timeline,
+transcript, target durations and aspect ratios. Outputs: candidate clips,
+vertical timelines, burned-in captions, platform-specific renders. This use case
+should likely remain human-reviewed until transcript selection and reframing
+quality are sufficiently reliable.
+
+## Competitive and Alternative Approaches
+
+- **Manual Resolve Editing** — Strengths: maximum creative control, immediate
+  visual feedback, no automation setup. Weaknesses: repetitive, hard to
+  standardize, hard to reproduce, slow for recurring formats.
+- **Direct Resolve Scripting** — Strengths: flexible, official automation
+  surface, suitable for custom engineering. Weaknesses: low-level, requires
+  substantial Resolve-specific knowledge, poor default safety and observability,
+  hard for agents to use reliably without additional structure.
+- **Generic MCP Server** — Strengths: easy to connect, broad tool exposure,
+  conversational interaction. Weaknesses: requires a running service; adds
+  connection/configuration failure modes; encourages overly granular tool use;
+  often lacks strong workflow policy; large tool surfaces; state and versioning
+  live outside the user's production repository.
+- **GUI Automation** — Strengths: can reach unsupported UI operations.
+  Weaknesses: fragile, hard to validate, sensitive to layout/application changes,
+  poor fit for broad automation.
+- **Proposed Harness** — Strengths: local and on demand, version controlled,
+  agent-friendly, workflow oriented, auditable, extensible, safer than broad
+  low-level access. Weaknesses: requires initial workflow design; Resolve API
+  limitations remain; cross-platform behavior may differ; some visual review
+  remains necessary.
+
+## Differentiation
+
+The product's differentiation would come from the combination of:
+coding-agent-native operation; opinionated production workflows; declarative edit
+specifications; repository-based configuration; structured inspection;
+postcondition validation; safe mutation controls; reproducible timeline
+generation; local execution without a persistent integration service.
+
+The central positioning: **A build system for repeatable video production in
+DaVinci Resolve.**
+
+## Roadmap
+
+### Phase 0: Technical Discovery and Feasibility
+
+**Objective** — Validate the limits of the Resolve scripting API and identify the
+smallest dependable automation surface.
+
+**Workstreams** — Test Resolve process discovery and connection; document API
+coverage for projects, media pools, timelines, clips, markers, subtitles, Fusion
+templates, and rendering; compare free and Studio editions; test macOS
+environment setup; evaluate stable identifier strategies; determine snapshot and
+rollback options; identify operations requiring GUI fallback; build a disposable
+integration-test project.
+
+**Deliverables** — Capability matrix; technical architecture proposal; API risk
+register; prototype doctor command; prototype project and timeline inspection;
+prototype render queue control; initial workflow candidate recommendation.
+
+**Exit Criteria** — Reliable connection to a running Resolve instance; structured
+project and timeline inspection; successful creation of a test timeline;
+successful enqueue and completion of a test render; documented limitations and
+failure modes.
+
+### Phase 1: Developer Preview
+
+**Objective** — Deliver a usable local harness for basic agent-driven timeline
+construction and rendering.
+
+**Features** — CLI project initialization; doctor diagnostics; project and
+timeline inspection; media import; bin creation; timeline creation; basic clip
+append and trim operations; markers; subtitle import; render preset selection;
+render queue control; JSON output; execution journal; dry-run support; snapshot
+command; agent policy template; initial YAML workflow format.
+
+**Initial Workflow** — Screen-recording tutorial or product walkthrough
+(comparatively structured, common among technical users, less dependent on
+subjective editing decisions).
+
+**Exit Criteria** — A coding agent can construct and render a basic walkthrough
+from documented inputs; the same workflow can be run repeatedly without
+duplicating assets or corrupting the timeline; failures produce actionable error
+messages; all workflow steps are recorded; users can inspect the resulting state
+programmatically.
+
+### Phase 2: Workflow Productization
+
+**Objective** — Move from a technical toolkit to repeatable end-user workflows.
+
+**Features** — Workflow schema validation; reusable workflow packages; template
+and preset registry; intro/outro insertion; parameterized title templates;
+caption workflow; audio validation; missing-media checks; preflight command;
+postcondition verification; workflow-specific documentation; example
+repositories; revision-safe timeline regeneration.
+
+**Candidate Workflows** — Screen tutorial; talking-head video; product
+walkthrough; podcast episode; review render; multi-format export.
+
+**Exit Criteria** — At least three workflows can be configured without modifying
+Python code; a user can create a new project from a documented template;
+workflows expose clear review checkpoints; rendered output meets configurable
+technical validation requirements.
+
+### Phase 3: Intelligent Editing Assistance
+
+**Objective** — Introduce AI-assisted editorial operations while preserving
+explicit review and reproducibility.
+
+**Features** — Transcript generation integration; transcript-to-timeline mapping;
+silence removal; filler-word detection; retake detection; chapter suggestion;
+candidate highlight extraction; speaker segmentation; content-aware marker
+generation; configurable editorial policies.
+
+**Product Constraint** — AI-assisted decisions should initially generate
+recommendations or editable workflow artifacts rather than silently modifying
+final timelines. For example:
+
+```yaml
+suggested_cuts:
+  - start: 00:01:14.200
+    end: 00:01:18.900
+    reason: repeated sentence
+    confidence: 0.94
+```
+
+The user or agent can review and accept those cuts before compilation.
+
+**Exit Criteria** — Suggested edits are traceable to transcript or media
+evidence; users can accept, reject, or modify suggestions; applying suggestions
+produces deterministic timeline changes; the harness can explain why an edit was
+proposed.
+
+### Phase 4: Team and Pipeline Capabilities
+
+**Objective** — Support shared production standards and broader content
+operations.
+
+**Features** — Shared workflow registry; organization-level presets; template
+package versioning; CI validation of workflow files; batch project execution;
+render-node support; review artifact generation; approval metadata;
+content-management integrations; publishing hooks; asset-store integrations;
+project locking and concurrency controls.
+
+**Exit Criteria** — Teams can distribute and update shared workflows; projects can
+declare workflow and template versions; automated validation can run without
+performing destructive edits; render outputs can be traced to a workflow version
+and source revision.
+
+## MVP Recommendation
+
+The MVP should focus on one narrow but complete workflow: **screen-recording
+product walkthrough with voiceover.**
+
+**MVP Inputs** — Screen recording; voiceover audio; optional transcript; optional
+intro/outro; render configuration.
+
+**MVP Outputs** — Organized Resolve project; main timeline; synchronized screen
+and voiceover tracks; configurable pause reduction; captions when a transcript is
+present; chapter markers from configuration; review render; final render;
+execution report.
+
+**MVP Commands**
+
+```
+resolve-tool init
+resolve-tool doctor
+resolve-tool inspect
+resolve-tool validate video.yaml
+resolve-tool plan video.yaml
+resolve-tool apply video.yaml
+resolve-tool verify
+resolve-tool render review
+```
+
+**Why This Scope** — It tests the complete product thesis: agent-driven
+operation; declarative configuration; Resolve timeline mutation; inspection;
+validation; rendering; repeatability; human review. It avoids premature
+investment in highly subjective autonomous editing.
+
+## Functional Requirements
+
+**Environment and Connectivity** — Detect supported Resolve installations;
+confirm scripting is enabled; confirm the expected Python environment is
+available; report Resolve version and edition; detect whether Resolve is running;
+provide actionable remediation for connection failures.
+
+**Inspection** — List projects and timelines; identify the active project and
+timeline; list tracks, clips, markers, and media-pool items; report timeline
+format settings; report missing or offline media; report render jobs and status.
+
+**Mutation** — Create or select a project; create bins and import media; create
+timelines; add and trim clips; add markers; import subtitles; insert approved
+templates; configure render settings; queue and start renders.
+
+**Workflow Engine** — Load and validate workflow files; resolve file references;
+produce an execution plan; support dry runs; apply operations in dependency
+order; check postconditions; write execution journals; support reruns without
+uncontrolled duplication.
+
+**Safety** — Snapshot before broad changes; require explicit flags for
+destructive operations; prevent concurrent modification; preserve ingest
+timelines; validate output paths; block final rendering when preflight checks
+fail, unless explicitly overridden.
+
+## Non-Functional Requirements
+
+**Reliability** — Operations either complete successfully or fail with a clear
+recovery path; workflow runs are resumable where practical; partial failures do
+not leave ambiguous state.
+
+**Observability** — Every command supports structured output; workflow runs
+include timing, inputs, operations, outputs, warnings, and failures;
+postcondition results are explicit.
+
+**Extensibility** — New workflows are addable without modifying the core CLI;
+template and preset packages are versionable; organizations can define custom
+validation rules.
+
+**Portability** — Workflow specifications avoid platform-specific paths where
+possible; Resolve-version-specific behavior is isolated behind capability checks.
+
+**Security** — No network service is required by default; local paths and project
+metadata remain local unless the user configures an external integration;
+arbitrary code execution is not exposed through normal workflow configuration;
+external hooks require explicit enablement.
+
+## Key Technical Risks
+
+- **Resolve API Coverage** — Some operations may not be available or may behave
+  inconsistently. Mitigation: tested capability matrix; prefer supported
+  operations; isolate GUI fallbacks behind named commands; avoid promising
+  complete UI parity.
+- **State Identification** — Resolve objects may not provide stable identifiers.
+  Mitigation: combine native identifiers with harness-managed metadata; apply
+  markers/metadata tags to generated assets; maintain a project-local state
+  manifest.
+- **Idempotency** — Repeated execution may duplicate clips/timelines/bins/render
+  jobs. Mitigation: tag generated entities; compare desired and current state;
+  offer replace/merge/rebuild modes; generate execution plans before mutation.
+- **Timeline Reversibility** — Some edits may be hard to roll back
+  programmatically. Mitigation: snapshot projects/timelines; preserve source
+  timelines; prefer generated output timelines; record all applied operations.
+- **Cross-Version Compatibility** — Scripting behavior may change between
+  releases. Mitigation: version detection; automated compatibility tests;
+  version-specific adapters; published support matrix.
+- **Agent Misuse** — An agent may issue overly broad or unsafe commands.
+  Mitigation: safe defaults; agent policy files; command-level safeguards;
+  dry-run requirements; explicit destructive flags; constrained workflow schemas.
+
+## Success Metrics
+
+**Activation** — % of users who complete `doctor` successfully; % who create and
+run their first workflow; time from installation to first review render.
+
+**Reliability** — Workflow success rate; % of runs requiring manual recovery;
+frequency of duplicate or inconsistent timeline state; render completion rate;
+postcondition validation pass rate.
+
+**Efficiency** — Time saved per recurring video; reduction in repetitive manual
+editing steps; deliverables produced per source timeline; % of workflow
+configuration reused across projects.
+
+**Product Adoption** — Active projects per user; repeat workflow runs; custom
+workflows created; shared templates/presets used; retention among users who
+complete an initial render.
+
+**Quality** — % of review renders accepted without structural timeline changes;
+manual corrections required after workflow execution; user-reported confidence in
+rerunning workflows; frequency of reverting to fully manual editing.
+
+## Open Product Questions
+
+1. Should the first release target only DaVinci Resolve Studio, or support both
+   editions with capability detection?
+2. Should the harness manage project creation, or initially require the user to
+   open an existing project?
+3. Should timelines be mutated in place, cloned before modification, or always
+   regenerated?
+4. What is the appropriate source of truth: workflow configuration, current
+   Resolve state, or a hybrid state manifest?
+5. How should users review execution plans before applying changes?
+6. Which operations can be made genuinely idempotent?
+7. Should transcript generation be built in or treated as an external
+   preprocessing step?
+8. How should Fusion templates be packaged and versioned?
+9. What level of audio processing should be included before integration with
+   external tools becomes preferable?
+10. Should the initial product be a general developer tool or a packaged
+    application for less technical creators?
+11. What is the minimum supported Resolve version?
+12. How should the product communicate partial support and version-specific
+    limitations?
+13. Should the CLI be open source, commercially licensed, or split into an open
+    core and paid workflow library?
+14. Is the primary buyer an individual creator, a technical marketing team, or a
+    media-production organization?
+15. What review interface, if any, is needed beyond Resolve itself and generated
+    reports?
+
+## Recommended Product Decisions
+
+For the first roadmap cycle: target macOS first; support an already-running
+Resolve instance; start with a CLI and repository template; use YAML as the
+primary workflow format; treat generated timelines as disposable outputs where
+practical; preserve original media and ingest timelines; focus on screen-recording
+and product-walkthrough workflows; require human review before final rendering;
+keep transcript generation external initially; support only named, controlled GUI
+fallbacks; optimize for coding agents rather than conversational assistants; avoid
+a persistent background service; publish a clear capability and compatibility
+matrix; prioritize inspection, validation, and repeatability over breadth.
+
+## Proposed Milestones
+
+- **Milestone 1: Resolve Connectivity** — Environment diagnostics; version
+  detection; project discovery; timeline inspection; test project automation.
+- **Milestone 2: Deterministic Timeline Build** — Media import; bin management;
+  timeline creation; clip placement; basic trimming; markers; state manifest.
+- **Milestone 3: Workflow Execution** — YAML schema; plan and apply commands; dry
+  runs; execution journals; postcondition checks; snapshots.
+- **Milestone 4: Review Render Pipeline** — Render presets; render queue control;
+  status inspection; review and final outputs; output validation.
+- **Milestone 5: First Packaged Workflow** — Screen-recording walkthrough;
+  voiceover synchronization; pause reduction; captions; intro/outro; documentation
+  and sample repository.
+- **Milestone 6: Developer Preview** — Installer; example projects; compatibility
+  documentation; feedback instrumentation; issue templates; extension
+  documentation.
+
+## Go/No-Go Criteria
+
+Proceed beyond technical discovery only if the team can demonstrate: reliable
+programmatic connection to supported Resolve versions; sufficient timeline and
+render control for one complete workflow; a workable approach to project state
+identification; acceptable recovery from partial failures; a repeatable workflow
+that produces the same structural result across multiple runs; clear user value
+compared with direct scripting; a credible path around API limitations without
+depending on broad GUI automation.
+
+Reconsider or narrow the project if: core timeline operations cannot be performed
+consistently; stable state comparison is not feasible; version compatibility
+requires excessive maintenance; most target workflows require fragile UI
+automation; users still need to perform nearly all structural editing manually.
+
+## Strategic Opportunity
+
+The immediate product is a Resolve automation harness, but the broader opportunity
+is a framework for agent-driven creative production. The durable product value
+would not come from wrapping a video-editor API — it would come from defining how
+coding agents safely operate stateful creative applications: inspect current
+state; express intended state; generate an execution plan; apply bounded changes;
+verify outcomes; preserve history; support human review; reproduce outputs.
+
+DaVinci Resolve is a strong initial domain because it combines a professional
+production environment, an existing scripting surface, repeated operational
+workflows, and users who already rely on templates, presets, and structured
+production conventions.
+
+## Recommendation
+
+Proceed with a short technical-discovery phase focused on one end-to-end
+workflow: a screen-recording product walkthrough with voiceover, captions, and
+two render outputs.
+
+The purpose of this phase should not be to maximize Resolve API coverage. It
+should determine whether the team can deliver a workflow that is: repeatable;
+inspectable; recoverable; agent-friendly; safer than direct scripting;
+meaningfully faster than manual production.
+
+A successful prototype should produce both a working video timeline and evidence
+that the workflow can be rerun, revised, and audited without constant manual
+intervention.


### PR DESCRIPTION
## Summary

Bootstraps stack-control governance in `video-control` and inaugurates the roadmap with the DaVinci Resolve automation-harness product brief.

## Commits

- **`f045fb3` — stack-control scaffolding.** `.stack-control/config.yaml` + governed working files (ROADMAP, DESIGN-INBOX, backlog store, audit log, fleet knowledge), created via `stackctl setup`.
- **`ea3eae1` — roadmap inauguration.** The product brief encoded as an 11-node governed DAG under `multi:feature/resolve-automation-harness`, with the full brief preserved at `docs/product-brief-resolve-harness.md`.

## Roadmap structure (milestone spine + phase epics)

```
design:feature/technical-discovery       ◀ ready frontier (Phase 0 go/no-go gate)
  └─ impl:feature/resolve-connectivity               (M1)
       └─ impl:feature/deterministic-timeline-build  (M2)
            └─ impl:feature/workflow-execution-engine (M3)
                 └─ impl:feature/review-render-pipeline (M4)
                      └─ impl:feature/screen-walkthrough-mvp (M5 · MVP)
                           └─ impl:feature/developer-preview (M6)
                                └─ multi:feature/workflow-productization (Phase 2)
                                     ├─ multi:feature/intelligent-editing-assist (Phase 3)
                                     └─ multi:feature/team-pipeline-capabilities (Phase 4)
```

Order is derived from `depends-on` edges — discovery is the first actionable item, and the phase epics fork independently off productization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNejKzMfnnvutETuUpfFy2
